### PR TITLE
Add CNAME entry for bulkscan in perftest

### DIFF
--- a/environments/perftest.yml
+++ b/environments/perftest.yml
@@ -14,3 +14,6 @@ A:
 txt:
 
 cname:
+  - name: "bulkscan"
+    ttl: 3600
+    record: "ad037a62-5f44-4add-9862-ecf0f1d6e7f8.cloudapp.net"

--- a/environments/perftest.yml
+++ b/environments/perftest.yml
@@ -22,4 +22,4 @@ cname:
     record: "hmcts-perftest.azurefd.net"
   - name: "bulkscan"
     ttl: 3600
-    record: "ad037a62-5f44-4add-9862-ecf0f1d6e7f8.cloudapp.net"
+    record: "bulkscanperftest.blob.core.windows.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Build bulkscan shared infra](https://tools.hmcts.net/jira/browse/BPS-1029)

### Change description ###

Reference: one of the errors - [Jenkins build](https://build.platform.hmcts.net/view/BSP/job/HMCTS_BSP/job/bulk-scan-shared-infrastructure/job/perftest/9/execution/node/76/log/)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
