### PR TITLE
Update reform scan prod record (cname mapping issue fix)

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -449,7 +449,7 @@ cname:
     record: "awverify.probate-frontend-prod-shutter.azurewebsites.net"
   - name: "reformscan"
     ttl: 3600
-    record: "adae2575-b89f-49d9-9d95-43aaf8a3a71f.cloudapp.net"
+    record: "reformscanprod.blob.core.windows.net"
   - name: "asverify.reformscan"
     ttl: 3600
     record: "asverify.reformscanprod.blob.core.windows.net"


### PR DESCRIPTION
### Change description ###

Update reform scan prod record temporarily to resolve cname mapping issue for master build. When blob storage gets created (currently prod resources are being built), the entry will be updated again.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
