### PR TITLE
Make all DNS apply run in parallel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,7 @@ stages:
           terraformVersion: ${{ variables.terraformVersion }}
 
   - stage: Aat_Apply
-    dependsOn: Perftest_Apply
+    dependsOn: Plan_phase
     displayName: "AAT Apply"
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     jobs:
@@ -130,7 +130,7 @@ stages:
           terraformVersion: ${{ variables.terraformVersion }}
 
   - stage: Prod_Apply
-    dependsOn: Aat_Apply
+    dependsOn: Plan_phase
     displayName: "Prod Apply"
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     jobs:


### PR DESCRIPTION
Given the DNS module is very stable and changes are usually targeted to an environment it doesn't make a lot of sense waiting for other environments before the next one,

This will also speed up shuttering quite a bit