### PR TITLE
Remove PCQ public DNS

### DIFF
--- a/environments/aat.yml
+++ b/environments/aat.yml
@@ -116,9 +116,6 @@ cname:
   - name: "afdverify.pcq"
     ttl: 300
     record: "afdverify.hmcts-aat.azurefd.net"
-  - name: "pcq"
-    ttl: 300
-    record: "hmcts-aat.azurefd.net"
   - name: "afdverify.adoption"
     ttl: 300
     record: "afdverify.hmcts-aat.azurefd.net"


### PR DESCRIPTION
### Change description ###

Removing PCQ AAT public DNS to ensure only access via VPN is allowed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
