### PR TITLE
add alias record for hmcts-access to front door (SIDAM 2.0)

### DIFF
--- a/components/prod/hmcts-access.tf
+++ b/components/prod/hmcts-access.tf
@@ -1,6 +1,7 @@
 module "hmcts-access" {
   source              = "../../modules/azure-public-dns/"
   cname_records       = yamldecode(data.local_file.hmcts-access-config.content).cname
+  alias_recordsets    = yamldecode(data.local_file.hmcts-access-config.content).alias
   zone_name           = azurerm_dns_zone.hmcts-access.name
   resource_group_name = data.azurerm_resource_group.main.name
   env                 = var.env

--- a/environments/prod/hmcts-access-service-gov-uk.yml
+++ b/environments/prod/hmcts-access-service-gov-uk.yml
@@ -23,3 +23,8 @@ cname:
   - name: "cdnverify"
     ttl: 3600
     record: "cdnverify.hmcts-hmcts-access-shutter-prod.azureedge.net"
+
+alias:
+  - name: "@"
+    ttl: 300
+    target_resource_id: "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourceGroups/lz-prod-rg/providers/Microsoft.Network/frontdoors/hmcts-prod"

--- a/modules/azure-public-dns/alias_record.tf
+++ b/modules/azure-public-dns/alias_record.tf
@@ -1,0 +1,12 @@
+resource "azurerm_dns_a_record" "this_alias" {
+  for_each = { for record in var.alias_recordsets :
+    record.name => record
+  }
+
+  resource_group_name = lower(var.resource_group_name)
+  zone_name           = var.zone_name
+
+  name    = lower(each.value.name)
+  ttl     = each.value.ttl
+  target_resource_id   = each.value.target_resource_id
+}

--- a/modules/azure-public-dns/variables.tf
+++ b/modules/azure-public-dns/variables.tf
@@ -25,4 +25,7 @@ variable "txt_recordsets" {
 variable "srv_recordsets" {
   default = []
 }
+variable "alias_recordsets" {
+  default = []
+}
 variable "env" {}


### PR DESCRIPTION
### Change description ###

- Add support for alias A record types to module
- Add record for hmcts-access.service.gov.uk => prod azure front door

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
