### PR TITLE
Added reform scan staging to prod

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -494,6 +494,12 @@ cname:
   - name: "asverify.reformscan"
     ttl: 3600
     record: "asverify.reformscanprod.blob.core.windows.net"
+  - name: "asverify.reformscanstg"
+    ttl: 300
+    record: "asverify.reformscanprodstaging.blob.core.windows.net"
+  - name: "reformscanstg"
+    ttl: 300
+    record: "reformscanprodstaging.blob.core.windows.net"
   - name: "register-org"
     ttl: 60
     record: "hmcts-prod.azurefd.net"


### PR DESCRIPTION
- Adding this to make build successful.

- Staging prod would not be used externally by any consumer.