### PR TITLE
Temporarily point DNS to blob store for progressing build

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -302,7 +302,7 @@ cname:
     record: "hmcts-sscs-tribunals-frontend-prod.trafficmanager.net"
   - name: "bulkscan"
     ttl: 60
-    record: "0c825335-3be3-454d-af9a-ff6a54a9fbc2.cloudapp.net"
+    record: "bulkscanprod.blob.core.windows.net"
   - name: "asverify.bulkscan"
     ttl: 60
     record: "asverify.bulkscanprod.blob.core.windows.net"


### PR DESCRIPTION
- App GW was rebuilt as subnet had to be recreated due to bulk scan subnet running out of capacity.