### PR TITLE
SIDM-4651 - chore(idam): remove legacy dns record for traffic manager ingress

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -562,9 +562,6 @@ cname:
   - name: "tmbenefit-appeal"
     ttl: 3600
     record: "58fd15f9-7a11-4de2-8df1-9aef0e807ec2.cloudapp.net"
-  - name: "tmidam-web-public"
-    ttl: 60
-    record: "7436ed5c-c64c-4053-9c36-6d8ee8702a6d.cloudapp.net"
   - name: "tmmanage-case"
     ttl: 300
     record: "3ea55565-0202-4fa4-a74b-e9b0bccdefd5.cloudapp.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-4651

### Change description ###

chore(idam): remove legacy dns record for traffic manager ingress.

`tmidam-web-public.platform.hmcts.net` may be vulnerable to subdomain takeover.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```