### PR TITLE
SIDM-4348 - Remove legacy DNS

### DIFF
--- a/environments/aat.yml
+++ b/environments/aat.yml
@@ -158,12 +158,6 @@ cname:
   - name: "immigration-appeal"
     ttl: 3600
     record: "hmcts-aat.azurefd.net"
-  - name: "afdverify.idam-web-public-aat2"
-    ttl: 3600
-    record: "afdverify.hmcts-aat.azurefd.net"
-  - name: "idam-web-public-aat2"
-    ttl: 3600
-    record: "hmcts-aat.azurefd.net"
   - name: "afdverify.idam-web-public"
     ttl: 3600
     record: "afdverify.hmcts-aat.azurefd.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-4348

### Change description ###

Remove legacy DNS

There are a number of unknown to IDAM DNS records in the production directory. Some examples include:

```
  - name: "idam-demo.dev.ccidam"
  - name: "api-dev1.fridam"
  - record: "idam.reform.hmcts.net"
```

Who is the owner of these records?

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```