### PR TITLE
DTSPO-1597 - DTSPO Nonprod Sendgrid domain authentication records

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -867,4 +867,12 @@ cname:
   - name: "_e57ed8697414f710e606332e9e5741dd.www.track-appeal"
     ttl: 300
     record: "6D28C9A3B93B9404BDEE45E9AB45A95B.693442FE0373E2397C68A390C62F5DD9.effa3b908aaa9f8744b9.comodoca.com."
-    
+  - name: "em4964.mail-dtspo-nonprod"
+    ttl: 300
+    record: "u20784268.wl019.sendgrid.net"
+  - name: "s1._domainkey.mail-dtspo-nonprod"
+    ttl: 300
+    record: "s1.domainkey.u20784268.wl019.sendgrid.net"
+  - name: "s2._domainkey.mail-dtspo-nonprod"
+    ttl: 300
+    record: "s2.domainkey.u20784268.wl019.sendgrid.net"    


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-1597


### Change description ###
Added sendgrid domain authentication records for dtspo non-prod sendgrid account.
Account is primary account for subsequent sendgrid subuser accounts


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
