### PR TITLE
DTSPO-2599: Sandbox temp deletion of CDN verify records to allow custom domains removal

### DIFF
--- a/environments/sandbox.yml
+++ b/environments/sandbox.yml
@@ -83,9 +83,6 @@ cname:
   - name: "afdverify.idam-web-public"
     ttl: 300
     record: "afdverify.hmcts-sbox.azurefd.net"
-  - name: "cdnverify.idam-web-public"
-    ttl: 300
-    record: "cdnverify.hmcts-idam-web-public-shutter-sbox.azureedge.net"
   - name: "idam-web-public"
     ttl: 300
     record: "hmcts-sbox.azurefd.net"
@@ -93,9 +90,6 @@ cname:
   - name: "afdverify.idam-web-public-sprod"
     ttl: 300
     record: "afdverify.hmcts-sbox.azurefd.net"
-  - name: "cdnverify.idam-web-public-sprod"
-    ttl: 300
-    record: "cdnverify.hmcts-idam-web-public-sprod-shutter-sbox.azureedge.net"
   - name: "idam-web-public-sprod"
     ttl: 300
     record: "hmcts-sbox.azurefd.net"
@@ -103,9 +97,6 @@ cname:
   - name: "afdverify.idam-web-admin"
     ttl: 300
     record: "afdverify.hmcts-sbox.azurefd.net"
-  - name: "cdnverify.idam-web-admin"
-    ttl: 300
-    record: "cdnverify.hmcts-idam-web-admin-shutter-sbox.azureedge.net"
   - name: "idam-web-admin"
     ttl: 300
     record: "hmcts-sbox.azurefd.net"
@@ -117,9 +108,6 @@ cname:
     ttl: 300
     record: "hmcts-sbox.azurefd.net"
     shutter: false
-  - name: "cdnverify.reformscan"
-    ttl: 300
-    record: "cdnverify.hmcts-reformscan-shutter-sbox.azureedge.net"
   - name: "toffee"
     ttl: 300
     record: "sdshmcts-sbox.azurefd.net"
@@ -127,9 +115,6 @@ cname:
   - name: "afdverify.toffee"
     ttl: 3600
     record: "afdverify.sdshmcts-sbox.azurefd.net"
-  - name: "cdnverify.hmi-apim"
-    ttl: 300
-    record: "cdnverify.hmcts-hmi-apim-shutter-sbox.azureedge.net"
   - name: "_9af30f185640a6f0617d0d1ef8e9de95"
     ttl: 300
     record: "2135FD8EB464CCFADFCD6999525A52F0.230B7360D54C272A4FB658B45A962B2E.eb30a0ede6e02b3430fe.comodoca.com."


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2599


### Change description ###
Temporarily removing sandbox CDN verify records to allow CDN resource replacement (testing CDN sku change) which is currently blocked by existing DNS records.

![image](https://user-images.githubusercontent.com/22701260/117987653-971e1580-b332-11eb-9fc9-c89872d8d9f4.png)

Records will be added back after resource removal.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
