### PR TITLE
Revert "Shuttering money clams legal for PBA V2 Release (#589)"

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -327,7 +327,7 @@ cname:
   - name: "www.moneyclaim-legal"
     ttl: 300
     record: "hmcts-prod.azurefd.net"
-    shutter: true
+    shutter: false
   - name: "divorce.nonprod"
     ttl: 3600
     record: "mojmaintenance.azurewebsites.net"


### PR DESCRIPTION
### Change description ###

un-shuttering money claims legal for PBA V2 Release

> This reverts commit 0bd5decc57b4921a7b57420e7e0ec2ecda120eef. (PR#https://github.com/hmcts/azure-public-dns/pull/589)

This PR is part of the change `CHG5004520`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
