### PR TITLE
Point dns record for dev-in.mailrelay cert

### DIFF
--- a/environments/prod/mailrelay-platform-hmcts-net.yml
+++ b/environments/prod/mailrelay-platform-hmcts-net.yml
@@ -44,4 +44,7 @@ txt:
     record:
       - "v=DMARC1; p=none"
 
-cname: []
+cname:
+  - name: "_93C2F3E02CA882E3F4FD39F6EFA6F73F.dev-in"
+    ttl: 300
+    record: "B60805165EF963DEA79E46FEE7FD460B.3711E2BDE60B142259B1F76AA2FDFB27.a9bd402e9971cc6f171e.comodoca.com."


### PR DESCRIPTION
Pointing of the DNS for dev-in.mailrelay ssl.
Currently failing as https://releases.hashicorp.com/ is not available, but will rerun when available again.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
