### PR TITLE
DNS records for cman, mcol and mcnotify in prod

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -711,3 +711,12 @@ cname:
   - name: "s2._domainkey.mail-am"
     ttl: 300
     record: "s2.domainkey.u22723469.wl220.sendgrid.net"
+  - name: "mcol"
+    ttl: 300
+    record: "firewall-prod-int-palo-mcolprod.uksouth.cloudapp.azure.com"
+  - name: "mcnotify"
+    ttl: 300
+    record: "firewall-prod-int-palo-mcolprod.uksouth.cloudapp.azure.com"
+  - name: "cman"
+    ttl: 300
+    record: "firewall-prod-int-palo-cmanprod.uksouth.cloudapp.azure.com"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-3299

https://tools.hmcts.net/jira/browse/DTSPO-3300

### Change description ###

Add CNAME to the public ip - traffic goes through hmcts-live-int/ext front door on the front end domain (e.g. mcol.apps.hmcts.net) > backend domain (CNAME'd to PIP)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
