### PR TITLE
LAU-268 Remove lau-case and lau-idam frontend

### DIFF
--- a/environments/ithc.yml
+++ b/environments/ithc.yml
@@ -140,18 +140,6 @@ cname:
   - name: "lau"
     ttl: 3600
     record: "hmcts-ithc.azurefd.net"
-  - name: "afdverify.lau-case"
-    ttl: 3600
-    record: "afdverify.hmcts-ithc.azurefd.net"
-  - name: "lau-case"
-    ttl: 3600
-    record: "hmcts-ithc.azurefd.net"
-  - name: "afdverify.lau-idam"
-    ttl: 3600
-    record: "afdverify.hmcts-ithc.azurefd.net"
-  - name: "lau-idam"
-    ttl: 3600
-    record: "hmcts-ithc.azurefd.net"
   - name: "afdverify.bar"
     ttl: 3600
     record: "afdverify.hmcts-ithc.azurefd.net"

--- a/environments/staging/aat.yml
+++ b/environments/staging/aat.yml
@@ -151,18 +151,6 @@ cname:
   - name: "lau"
     ttl: 300
     record: "hmcts-aat.azurefd.net"
-  - name: "afdverify.lau-case"
-    ttl: 300
-    record: "afdverify.hmcts-aat.azurefd.net"
-  - name: "lau-case"
-    ttl: 300
-    record: "hmcts-aat.azurefd.net"
-  - name: "afdverify.lau-idam"
-    ttl: 300
-    record: "afdverify.hmcts-aat.azurefd.net"
-  - name: "lau-idam"
-    ttl: 300
-    record: "hmcts-aat.azurefd.net"
   - name: "afdverify.adoption-web"
     ttl: 300
     record: "afdverify.hmcts-aat.azurefd.net"

--- a/environments/test/perftest.yml
+++ b/environments/test/perftest.yml
@@ -87,18 +87,6 @@ cname:
   - name: "lau"
     ttl: 3600
     record: "hmcts-perftest.azurefd.net"
-  - name: "afdverify.lau-case"
-    ttl: 3600
-    record: "afdverify.hmcts-perftest.azurefd.net"
-  - name: "lau-case"
-    ttl: 3600
-    record: "hmcts-perftest.azurefd.net"
-  - name: "afdverify.lau-idam"
-    ttl: 3600
-    record: "afdverify.hmcts-perftest.azurefd.net"
-  - name: "lau-idam"
-    ttl: 3600
-    record: "hmcts-perftest.azurefd.net"
   - name: "afdverify.bar"
     ttl: 3600
     record: "afdverify.hmcts-perftest.azurefd.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/LAU-268

### Change description ###

Remove Lau Case and Lau Idam frontend applications. These have been replaced with a single application Lau-Frontend.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
