### PR TITLE
Remove the afdverify from the apex subdomain - it needs to be in the …

### DIFF
--- a/environments/staging/casetracker-justice-gov-uk.yml
+++ b/environments/staging/casetracker-justice-gov-uk.yml
@@ -7,7 +7,6 @@ A:
     ttl: 60
     alias_target_resource_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/lz-stg-rg/providers/Microsoft.Network/frontdoors/sdshmcts-stg"
 
-txt:
+txt: []
 
-
-cname:
+cname: []

--- a/environments/staging/casetracker-justice-gov-uk.yml
+++ b/environments/staging/casetracker-justice-gov-uk.yml
@@ -11,6 +11,3 @@ txt:
 
 
 cname:
-  - name: "afdverify"
-    ttl: 300
-    record: "afdverify.sdshmcts-stg.azurefd.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4090

### Change description ###
Remove the afdverify CNAME from the staging subdomain apex record
It needs to be in the justice.gov.uk apex domain record


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
