### PR TITLE
Updated naming convention and added for each env (had to update sendgrid)

### DIFF
--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -40,13 +40,13 @@ cname:
   - name: "_44cb36f0c4dde84c9ff1534180bb24da"
     ttl: 300
     record: "56DDD5BB7BD629DD7B32C2EF75824ECB.4FDD1FE37015F188615E327886C95C9B.44e67a303e887000a548.comodoca.com."
-  - name: "em2252.mail-private-law-nonprod"
+  - name: "em9743.mail-prl-nonprod"
     ttl: 300
     record: "u24999805.wl056.sendgrid.net"
-  - name: "s1._domainkey.mail-private-law-nonprod"
+  - name: "s1._domainkey.mail-prl-nonprod.demo"
     ttl: 300
     record: "s1.domainkey.u24999805.wl056.sendgrid.net"
-  - name: "s2._domainkey.mail-private-law-nonprod"
+  - name: "s2._domainkey.mail-prl-nonprod.demo"
     ttl: 300
     record: "s2.domainkey.u24999805.wl056.sendgrid.net"
   - name: vh-video-web

--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -40,13 +40,13 @@ cname:
   - name: "_44cb36f0c4dde84c9ff1534180bb24da"
     ttl: 300
     record: "56DDD5BB7BD629DD7B32C2EF75824ECB.4FDD1FE37015F188615E327886C95C9B.44e67a303e887000a548.comodoca.com."
-  - name: "em9743.mail-prl-nonprod.demo"
+  - name: "em9743.mail-prl-nonprod"
     ttl: 300
     record: "u24999805.wl056.sendgrid.net"
-  - name: "s1._domainkey.mail-prl-nonprod.demo"
+  - name: "s1._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s1.domainkey.u24999805.wl056.sendgrid.net"
-  - name: "s2._domainkey.mail-prl-nonprod.demo"
+  - name: "s2._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s2.domainkey.u24999805.wl056.sendgrid.net"
   - name: vh-video-web

--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -40,7 +40,7 @@ cname:
   - name: "_44cb36f0c4dde84c9ff1534180bb24da"
     ttl: 300
     record: "56DDD5BB7BD629DD7B32C2EF75824ECB.4FDD1FE37015F188615E327886C95C9B.44e67a303e887000a548.comodoca.com."
-  - name: "em9743.mail-prl-nonprod"
+  - name: "em9743.mail-prl-nonprod.demo"
     ttl: 300
     record: "u24999805.wl056.sendgrid.net"
   - name: "s1._domainkey.mail-prl-nonprod.demo"

--- a/environments/dev/preview.yml
+++ b/environments/dev/preview.yml
@@ -27,13 +27,13 @@ cname:
   - name: "_c67fec9b0864f2bb0714ad20237737b8"
     ttl: 60
     record: "F34A65BD30EBB2DFDFB79A4AA2BB1DE2.345B5C367A0AB72A72BDE0D54D9AA0E7.09ce3c5fe952c1b21211.comodoca.com."
-  - name: "em2252.mail-private-law-nonprod"
+  - name: "	em6134.mail-prl-nonprod"
     ttl: 300
     record: "u24999805.wl056.sendgrid.net"
-  - name: "s1._domainkey.mail-private-law-nonprod"
+  - name: "s1._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s1.domainkey.u24999805.wl056.sendgrid.net"
-  - name: "s2._domainkey.mail-private-law-nonprod"
+  - name: "s2._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s2.domainkey.u24999805.wl056.sendgrid.net"
 

--- a/environments/dev/preview.yml
+++ b/environments/dev/preview.yml
@@ -27,7 +27,7 @@ cname:
   - name: "_c67fec9b0864f2bb0714ad20237737b8"
     ttl: 60
     record: "F34A65BD30EBB2DFDFB79A4AA2BB1DE2.345B5C367A0AB72A72BDE0D54D9AA0E7.09ce3c5fe952c1b21211.comodoca.com."
-  - name: "	em6134.mail-prl-nonprod"
+  - name: "em6134.mail-prl-nonprod"
     ttl: 300
     record: "u24999805.wl056.sendgrid.net"
   - name: "s1._domainkey.mail-prl-nonprod"

--- a/environments/ithc.yml
+++ b/environments/ithc.yml
@@ -211,13 +211,13 @@ cname:
   - name: "_404182799e5e3fefe26b09d10f47bce9"
     ttl: 3600
     record: "17C2322AA10D8E2E87769BDD1EBC28EC.B245DB1A1DB26037B07B508290FC32A6.e56dbe0f3e1c9cecf699.comodoca.com."
-  - name: "em2252.mail-private-law-nonprod"
+  - name: "em8016.mail-prl-nonprod"
     ttl: 300
     record: "u24999805.wl056.sendgrid.net"
-  - name: "s1._domainkey.mail-private-law-nonprod"
+  - name: "s1._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s1.domainkey.u24999805.wl056.sendgrid.net"
-  - name: "s2._domainkey.mail-private-law-nonprod"
+  - name: "s2._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s2.domainkey.u24999805.wl056.sendgrid.net"
   - name: vh-video-web

--- a/environments/staging/aat.yml
+++ b/environments/staging/aat.yml
@@ -229,12 +229,12 @@ cname:
   - name: "_4c2aa3cf7820ad559328554b0084d4af"
     ttl: 300
     record: "A8DE39B21BE7C0E63C7D0233E683637A.205D792E60EE2E5C66131C38BCD98C87.aad64398a969ec318680.comodoca.com."
-  - name: "em2252.mail-private-law-nonprod"
+  - name: "em2383.mail-prl-nonprod"
     ttl: 300
     record: "u24999805.wl056.sendgrid.net"
-  - name: "s1._domainkey.mail-private-law-nonprod"
+  - name: "s1._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s1.domainkey.u24999805.wl056.sendgrid.net"
-  - name: "s2._domainkey.mail-private-law-nonprod"
+  - name: "s2._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s2.domainkey.u24999805.wl056.sendgrid.net"

--- a/environments/test/perftest.yml
+++ b/environments/test/perftest.yml
@@ -189,12 +189,12 @@ cname:
   - name: "_1b8b380f5b498882531eade6c02400cd"
     ttl: 3600
     record: "F9A67113DE1A34EE3AB88C964719B045.D0CB73465718E425F308BE76B7946D22.b49fdab097253cac48e3.comodoca.com."
-  - name: "em2252.mail-private-law-nonprod"
+  - name: "em8852.mail-prl-nonprod"
     ttl: 300
     record: "u24999805.wl056.sendgrid.net"
-  - name: "s1._domainkey.mail-private-law-nonprod"
+  - name: "s1._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s1.domainkey.u24999805.wl056.sendgrid.net"
-  - name: "s2._domainkey.mail-private-law-nonprod"
+  - name: "s2._domainkey.mail-prl-nonprod"
     ttl: 300
     record: "s2.domainkey.u24999805.wl056.sendgrid.net"


### PR DESCRIPTION
### Change description ###

Change of "product name" and added for each environment as domain is prefixed with env (e.g. aat.platform.hmcts.net)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
