### PR TITLE
DTSPO-8837 - Add cdnverify record for paymentoutcome-web

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -350,6 +350,9 @@ cname:
     ttl: 300
     record: "hmcts-prod.azurefd.net"
     shutter: false
+  - name: "cdnverify.paymentoutcome-web"
+    ttl: 300
+    record: "cdnverify.hmcts-paymentoutcome-web-shutter-prod.azureedge.net"
   - name: "probate"
     ttl: 60
     record: "6a9d29fa-e848-4bc7-b62b-31f7e3979eda.cloudapp.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-8837


### Change description ###
azure-platform-terraform pipeline currently fails at shutter stage due to missing dns for paymentoutcome-web custom domain which stops the custom domain being added to the endpoint:

```
We couldn't find a DNS record for 'paymentoutcome-web.platform.hmcts.net' that points to 'hmcts-paymentoutcome-web-shutter-prod.azureedge.net'. Before you can associate a domain with this CDN endpoint, you need to create a CNAME record with 
your DNS provider for 'paymentoutcome-web.platform.hmcts.net' that points to 'hmcts-paymentoutcome-web-shutter-prod.azureedge.net'.
```

Latest pipeline failure: https://dev.azure.com/hmcts/CNP/_build/results?buildId=237569&view=logs&j=e6b7f08a-a340-52af-23b1-0c34da204a44&t=e897f3bb-5c3e-59e9-f081-972334ed148e


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
