### PR TITLE
DTSPO-9705: Adding spf record entries for dev-in and prod-in for mailrelay2

### DIFF
--- a/environments/prod/mailrelay-platform-hmcts-net.yml
+++ b/environments/prod/mailrelay-platform-hmcts-net.yml
@@ -38,7 +38,7 @@ txt:
   - name: "prod-in"
     ttl: 3600
     record:
-      - "v=spf1 ip4:51.132.173.173 include:spf.protection.outlook.com -all"
+      - "v=spf1 ip4:20.50.108.242 ip4:20.50.109.148 ip4:51.11.124.205 ip4:51.11.124.216 include:spf.protection.outlook.com -all"
   - name: "_dmarc.prod-in"
     ttl: 3600
     record:
@@ -46,7 +46,7 @@ txt:
   - name: "dev-in"
     ttl: 3600
     record:
-      - "v=spf1 ip4:51.142.80.160 include:spf.protection.outlook.com -all"
+      - "v=spf1 ip4:20.49.168.141 ip4:20.49.168.17 ip4:51.11.124.149 ip4:51.11.124.158 include:spf.protection.outlook.com -all"
   - name: "_dmarc.dev-in"
     ttl: 3600
     record:

--- a/environments/prod/mailrelay-platform-hmcts-net.yml
+++ b/environments/prod/mailrelay-platform-hmcts-net.yml
@@ -38,7 +38,7 @@ txt:
   - name: "prod-in"
     ttl: 3600
     record:
-      - "v=spf1 ip4:20.50.108.242 ip4:20.50.109.148 ip4:51.11.124.205 ip4:51.11.124.216 include:spf.protection.outlook.com -all"
+      - "v=spf1 ip4:20.50.108.242 ip4:20.50.109.148 ip4:51.11.124.205 ip4:51.11.124.216 include:spf.protection.outlook.com ~all"
   - name: "_dmarc.prod-in"
     ttl: 3600
     record:
@@ -46,7 +46,7 @@ txt:
   - name: "dev-in"
     ttl: 3600
     record:
-      - "v=spf1 ip4:20.49.168.141 ip4:20.49.168.17 ip4:51.11.124.149 ip4:51.11.124.158 include:spf.protection.outlook.com -all"
+      - "v=spf1 ip4:20.49.168.141 ip4:20.49.168.17 ip4:51.11.124.149 ip4:51.11.124.158 include:spf.protection.outlook.com ~all"
   - name: "_dmarc.dev-in"
     ttl: 3600
     record:

--- a/environments/prod/mailrelay-platform-hmcts-net.yml
+++ b/environments/prod/mailrelay-platform-hmcts-net.yml
@@ -10,10 +10,6 @@ A:
       - "20.50.109.148"
       - "51.11.124.205"
       - "51.11.124.216"
-  - name: "prod-in"
-    ttl: 60
-    record:
-      - "51.132.173.173"
   - name: "dev"
     ttl: 60
     record:
@@ -39,6 +35,22 @@ txt:
     ttl: 3600
     record:
       - "v=DMARC1; p=none"
+  - name: "prod-in"
+    ttl: 3600
+    record:
+      - "v=spf1 ip4:51.132.173.173 include:spf.protection.outlook.com -all"
+  - name: "_dmarc.prod-in"
+    ttl: 3600
+    record:
+      - "v=DMARC1; p=none"
+  - name: "dev-in"
+    ttl: 3600
+    record:
+      - "v=spf1 ip4:51.142.80.160 include:spf.protection.outlook.com -all"
+  - name: "_dmarc.dev-in"
+    ttl: 3600
+    record:
+      - "v=DMARC1; p=none"
 
 cname:
   - name: "_93C2F3E02CA882E3F4FD39F6EFA6F73F.dev-in"
@@ -47,3 +59,6 @@ cname:
   - name: "dev-in"
     ttl: 60
     record: "ss-dev-mailrelay.trafficmanager.net"
+  - name: "prod-in"
+    ttl: 60
+    record: "ss-prod-mailrelay.trafficmanager.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-9705](https://tools.hmcts.net/jira/browse/DTSPO-9705)


### Change description ###
Updating DNS records for mailrelay2 and adding `spf` entries to mitigate spoofing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
