### PR TITLE
Remove splash page for Public portal 2.29

### DIFF
--- a/environments/prod/reply-jury-summons-service-gov-uk.yml
+++ b/environments/prod/reply-jury-summons-service-gov-uk.yml
@@ -6,8 +6,8 @@ A:
   - name: "@"
     ttl: 60
     # uncomment to shutter (and comment the other one)
-    alias_target_resource_id: "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/sds-platform-prod-rg/providers/Microsoft.Cdn/profiles/hmcts-shutter-jd-reply-jury-summons/endpoints/hmcts-reply-jury-summons-shutter-prod"
-    #alias_target_resource_id: "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/lz-prod-rg/providers/Microsoft.Network/frontdoors/sdshmcts-prod"
+    #alias_target_resource_id: "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/sds-platform-prod-rg/providers/Microsoft.Cdn/profiles/hmcts-shutter-jd-reply-jury-summons/endpoints/hmcts-reply-jury-summons-shutter-prod"
+    alias_target_resource_id: "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/lz-prod-rg/providers/Microsoft.Network/frontdoors/sdshmcts-prod"
 
 txt:
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Remove splash page for the Public portal after upgrade to 2.29.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
