### PR TITLE
PUB-1486 Added PIP B2C txt records

### DIFF
--- a/environments/staging/staging.yml
+++ b/environments/staging/staging.yml
@@ -17,10 +17,18 @@ A:
     ttl: 300
 
 txt: 
-  - name: "@"
+  - name: "pip-frontend"
     ttl: 3600
     record:
-      - "MS=ms92490321"
+      - "MS=ms19809512"
+  - name: "sign-in.pip-frontend"
+    ttl: 3600
+    record:
+      - "MS=ms46404176"
+  - name: "staff.pip-frontend"
+    ttl: 3600
+    record:
+      - "MS=ms84812883"
 
 srv: []
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1486

### Change description ###

- Removed original B2C txt record used by PIP
- Added new txt records for each of the domains PIP B2C will use in staging

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
