### PR TITLE
Removed PIP b2c cname records to verify txt

### DIFF
--- a/environments/staging/staging.yml
+++ b/environments/staging/staging.yml
@@ -64,12 +64,6 @@ cname:
   - name: pip-frontend
     record: sdshmcts-stg.azurefd.net
     ttl: 300
-  - name: sign-in.pip-frontend
-    record: sdshmcts-stg.azurefd.net
-    ttl: 300
-  - name: staff.pip-frontend
-    record: sdshmcts-stg.azurefd.net
-    ttl: 300
   - name: "afdverify.pip-frontend"
     ttl: 300
     record: "afdverify.hmcts-stg.azurefd.net"


### PR DESCRIPTION
### Change description ###

Removed PIP B2C sub domain cname records so txt records to be propagated for B2C to verify.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
