### PR TITLE
pre-stg1-S28-827

### DIFF
--- a/environments/prod/pre-recorded-evidence-justice-gov-uk.yml
+++ b/environments/prod/pre-recorded-evidence-justice-gov-uk.yml
@@ -17,14 +17,10 @@ cname:
     record: "pre-testing.powerappsportals.com"
   - name: "portal-stg"
     ttl: 300
-    record: "pre-stg.powerappsportals.com"
+    record: "pre-stg1.powerappsportals.com"
   - name: "portal-demo"
     ttl: 300
     record: "pre-demo.powerappsportals.com"
   - name: "portal"
     ttl: 300
     record: "pre-prod.powerappsportals.com"
-  - name: "_18FBACA52BAEA05806CA7012CA715BB2.portal"
-    ttl: 300
-    record: "530C930BA75A95023693228A4E2CE9E1.45A667A0ACF7037A9118BC3C4D7E3E16.3f8dcd6ba8c3eafe3d3d.sectigo.com."
- 


### PR DESCRIPTION
### JIRA link (if applicable) ###

S28-827

### Change description ###
- Rename
"pre-stg1.powerappsportals.com" from "pre-stg.powerappsportals.com"

- Removed the cnames used for SSL verification.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
