### PR TITLE
Set lock to false when running terraform plan

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,3 +132,5 @@ stages:
                   product: ${{ variables.product }}
                   initCommandOptions: >
                     -backend-config resource_group_name=${{ deployment.resource_group_name }}
+                  planCommandOptions: >
+                    -lock=false


### PR DESCRIPTION
### Change description ###
Not sure why `lock` isn't set to false by default on plans, but adding it here so the state file doesn't get locked up on a plan. I can also add it to the templates if needs be. It caused some issues tonight.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
