### PR TITLE
RET-2055: Employment Tribunal shuttering

### DIFF
--- a/environments/prod/claim-et-sya-hmcts-net.yml
+++ b/environments/prod/claim-et-sya-hmcts-net.yml
@@ -7,13 +7,13 @@ A: []
 txt: []
 
 cname:
-  - name: "afdverify.et-sya"
-    ttl: 300
-    record: "afdverify.hmcts-prod.azurefd.net"
-  - name: "cdnverify.et-sya"
-    ttl: 300
-    record: "cdnverify.hmcts-et-sya-shutter-prod.azureedge.net"
-  - name: "et-sya"
-    ttl: 300
+  - name: "www"
+    ttl: 60
     record: "hmcts-prod.azurefd.net"
     shutter: false
+  - name: "afdverify.www"
+    ttl: 300
+    record: "afdverify.hmcts-prod.azurefd.net"
+  - name: "cdnverify.www"
+    ttl: 300
+    record: "cdnverify.hmcts-employment-tribunals-shutter-prod.azureedge.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2055

### Change description ###
Updating the dns information to employment tribunals to remove the et-sya prefix to the domain


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
