### PR TITLE
Demo migration batch 1

### DIFF
--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -88,8 +88,8 @@ cname:
     record: "afdverify.hmcts-demo.azurefd.net"
   - name: "petitioner-frontend-aks"
     ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "petitioner-frontend-aks"
+    record: "hmcts-demo.azurefd.net"
+  - name: "afdverify.petitioner-frontend-aks"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
   - name: "afdverify.pet-app1"

--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -92,48 +92,6 @@ cname:
   - name: "afdverify.petitioner-frontend-aks"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.pet-app1"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.pet-app2"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.benefit-appeal"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.sscs-cor"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.track-appeal"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.manage-case"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.manage-org"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.manage-org-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.administer-orgs"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.administer-orgs-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.register-org"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.civil-citizen-ui"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.moneyclaims"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.moneyclaims-legal"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
   - name: "fact"
     ttl: 300
     record: "hmcts-demo.azurefd.net"
@@ -146,73 +104,16 @@ cname:
   - name: "afdverify.fact-admin"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "rpts"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.rpts"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.nfdiv"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.nfdiv-apply-for-divorce"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.nfdiv-end-civil-partnership"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
   - name: "et-sya"
     ttl: 300
     record: "hmcts-demo.azurefd.net"
   - name: "afdverify.et-sya"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.immigration-appeal"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.wa-proto-frontend"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.gateway-ccd"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.gateway-ccd-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.ac-int-gateway-ccd"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.return-case-doc-ccd"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.return-case-doc-ccd-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.pcq"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.pcq-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.lau"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.lau-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.judicial-payments"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.adoption-web"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.probate"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.idam-web-public"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.idam-web-admin"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.hmcts-access"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
   - name: "paybubble"
@@ -227,42 +128,18 @@ cname:
   - name: "afdverify.paybubble-int"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.bar"
+  - name: "www.paymentoutcome-web"
     ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.bar-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.fees-register"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.fees-register-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.idam-user-dashboard"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.ds-ui"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.fis-ds-web"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.fis-ds-update-web"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.sptribs-frontend"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.privatelaw"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
+    record: "hmcts-demo.azurefd.net"
   - name: "paymentoutcome-web"
     ttl: 300
     record: "hmcts-demo.azurefd.net"
   - name: "afdverify.paymentoutcome-web"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "www.paymentoutcome-web-int"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "paymentoutcome-web-int"
     ttl: 300
     record: "hmcts-demo.azurefd.net"
@@ -270,9 +147,6 @@ cname:
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
   - name: "afdverify.paymentoutcome-web-int"
-    ttl: 300
-    record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.ecm-ip"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
   - name: "dss-update-case"

--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -68,18 +68,28 @@ cname:
   - name: "afdverify.plum"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
-
-
+  - name: "decree-nisi-aks"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.decree-nisi-aks"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "decree-absolute-aks"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.decree-absolute-aks"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "respond-divorce-aks"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.respond-divorce-aks"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
-  - name: "afdverify.petitioner-frontend-aks"
+  - name: "petitioner-frontend-aks"
+    ttl: 300
+    record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "petitioner-frontend-aks"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
   - name: "afdverify.pet-app1"
@@ -124,9 +134,15 @@ cname:
   - name: "afdverify.moneyclaims-legal"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "fact"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.fact"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "fact-admin"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.fact-admin"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
@@ -142,6 +158,9 @@ cname:
   - name: "afdverify.nfdiv-end-civil-partnership"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "et-sya"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.et-sya"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
@@ -196,9 +215,15 @@ cname:
   - name: "afdverify.hmcts-access"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "paybubble"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.paybubble"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "paybubble-int"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.paybubble-int"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
@@ -232,9 +257,15 @@ cname:
   - name: "afdverify.privatelaw"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "paymentoutcome-web"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.paymentoutcome-web"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"
+  - name: "paymentoutcome-web-int"
+    ttl: 300
+    record: "hmcts-demo.azurefd.net"
   - name: "afdverify.paymentoutcome-web-int"
     ttl: 300
     record: "afdverify.hmcts-demo.azurefd.net"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12614

This change:
- Moves some initial apps over to FD active active setup with permanent dns mapping.
- Will go in tangent with a flux PR to remove tls flag from demo setup



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
