### PR TITLE
Removal of DomainConnect Record to 123Reg

### DIFF
--- a/environments/prod/ejudiciary-net.yml
+++ b/environments/prod/ejudiciary-net.yml
@@ -92,10 +92,6 @@ txt:
     ttl: 14400
     record:
       - "v=DMARC1;p=reject;sp=reject;fo=1;rua=mailto:dmarc-rua@dmarc.service.gov.uk"
-  - name: '_domainconnect'
-    ttl: 14400
-    record:
-      - "domainconnect.123-reg.co.uk"
   - name: '_mta-sts'
     ttl: 14400
     record:


### PR DESCRIPTION
Text Record with DNS Name _domainconnect where value = domainconnect.123-reg.co.uk deleted as this record will not be needed when transfer is complete.

### JIRA link (if applicable) ###
N/A


### Change description ###
N/A


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
