### PR TITLE
Revert "Enable ST shuttering in Prod"

### DIFF
--- a/environments/prod/special-tribunals-service-gov-uk.yml
+++ b/environments/prod/special-tribunals-service-gov-uk.yml
@@ -10,11 +10,11 @@ cname:
   - name: "www"
     ttl: 60
     record: "hmcts-prod.azurefd.net"
-    shutter: true
+    shutter: false
   - name: "afdverify.www"
     ttl: 300
     record: "afdverify.hmcts-prod.azurefd.net"
-    shutter: true
+    shutter: false
   - name: "cdnverify.www"
     ttl: 300
     record: "cdnverify.hmcts-special-tribunals-shutter-prod.azureedge.net"


### PR DESCRIPTION
For Special Tribunals Release 2 go live, we need to disable shuttering of the frontend application on our custom domain (https://www.special-tribunals.service.gov.uk).