### PR TITLE
Remove dangling CNAME

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -265,9 +265,6 @@ cname:
   - name: "www.apply-divorce"
     ttl: 60
     record: "www.apply-divorce.service.gov.uk"
-  - name: "benefit-appeal"
-    ttl: 60
-    record: "d9bb5705-1e1d-43d7-9a3d-8a7a97562873.cloudapp.net"
   - name: "gateway.ccd"
     ttl: 60
     record: "hmcts-prod.azurefd.net"


### PR DESCRIPTION
notified by GDS domains team

this must be really old it's pointing to an app gateway that doesn't exist anymore