### PR TITLE
DTSPO-13990 Updating dns for migrated test frontdoor

### DIFF
--- a/environments/sandbox.yml
+++ b/environments/sandbox.yml
@@ -174,7 +174,7 @@ cname:
     shutter: false
   - name: "toffee2"
     ttl: 300
-    record: "hmcts-test-sbox.azurefd.net"
+    record: "hmcts-test-sbox-bjcpanf7ave7a6ep.z01.azurefd.net"
     shutter: false
   - name: "afdverify.toffee"
     ttl: 3600


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSPO-13990](https://tools.hmcts.net/jira/browse/DTSPO-13990)

### Change description ###

Migrated hmcts-test-sbox to hmcts-test-sbox-migrated need to updated the dns to point to the new frontdoor


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
