### PR TITLE
DTSPO-15318: Remove conflicting A record

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -134,10 +134,6 @@ A:
     ttl: 60
     record:
       - "20.58.23.145"
-  - name: "static-sds-sandbox-build"
-    ttl: 60
-    record:
-      - "51.104.212.71"    
   - name: "sds-build"
     ttl: 60
     record:


### PR DESCRIPTION
DTSPO-15318 removes A record to allow CNAME from https://github.com/hmcts/azure-public-dns/commit/d4015b996e8b721fddb392856406b0b7727f88b5 to go through pipeline



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
