### PR TITLE
Records do not need the fqdn for name

### DIFF
--- a/environments/sandbox.yml
+++ b/environments/sandbox.yml
@@ -84,7 +84,10 @@ txt:
     record:
       - "ms-domain-verification=fb92e12a-fb28-48e0-b5ec-5fa92a9001c4"
       - "v=spf1 include:spf.protection.outlook.com -all"
-
+  - name: "_dnsauth.labs-goldenpath-mfox.sandbox.platform.hmcts.net"
+    ttl: 3600
+    record: "z5vl9sc7mn566pqxdbpxjggttvchpvqx"
+    
 # In order to swap the DNS for shutterring an application enable the shutter parameter for the corresponding application.
 # e.g. This will shutter the plum app in sbox environment
 #  - name: "plum"

--- a/environments/sandbox.yml
+++ b/environments/sandbox.yml
@@ -86,7 +86,8 @@ txt:
       - "v=spf1 include:spf.protection.outlook.com -all"
   - name: "_dnsauth.labs-goldenpath-mfox.sandbox.platform.hmcts.net"
     ttl: 3600
-    record: "z5vl9sc7mn566pqxdbpxjggttvchpvqx"
+    record: 
+      - "z5vl9sc7mn566pqxdbpxjggttvchpvqx"
     
 # In order to swap the DNS for shutterring an application enable the shutter parameter for the corresponding application.
 # e.g. This will shutter the plum app in sbox environment

--- a/environments/sandbox.yml
+++ b/environments/sandbox.yml
@@ -84,7 +84,7 @@ txt:
     record:
       - "ms-domain-verification=fb92e12a-fb28-48e0-b5ec-5fa92a9001c4"
       - "v=spf1 include:spf.protection.outlook.com -all"
-  - name: "_dnsauth.labs-goldenpath-mfox.sandbox.platform.hmcts.net"
+  - name: "_dnsauth.labs-goldenpath-mfox"
     ttl: 3600
     record: 
       - "z5vl9sc7mn566pqxdbpxjggttvchpvqx"


### PR DESCRIPTION
### Change description ###
Records do not need the fqdn for name, removing it from dns auth TXT record