### PR TITLE
Remove unneeded DNS entries

### DIFF
--- a/environments/prod/juror-bureau-justice-gov-uk.yml
+++ b/environments/prod/juror-bureau-justice-gov-uk.yml
@@ -11,10 +11,4 @@ A:
 txt:
 
 
-cname:
-  - name: "afdverify"
-    ttl: 300
-    record: "afdverify.sdshmcts-prod-egd0dscwgwh0bpdq.z01.azurefd.net"
-  - name: "cdnverify"
-    ttl: 300
-    record: "cdnverify.hmcts-jdbureau-shutter-prod.azureedge.net"
+cname: []


### PR DESCRIPTION
Neither of these are needed anymore.

MoJ-D reached out to me about this because of a dangling CNAME detected by CDDO