### PR TITLE
DTSPO-15899 Updated cname of the hmcts-nle-ext frontdoor

### DIFF
--- a/environments/prod/apps-nle-hmcts-net.yml
+++ b/environments/prod/apps-nle-hmcts-net.yml
@@ -33,16 +33,16 @@ cname:
     record: "hmcts-nle-int-cfgpbgagf9eedcar.z01.azurefd.net"
   - name: "mcnotify"
     ttl: 300
-    record: "hmcts-nle-ext.azurefd.net"
+    record: "hmcts-nle-ext-h8cqggf7c7ffhbh4.z01.azurefd.net"
   - name: "mcol"
     ttl: 300
-    record: "hmcts-nle-ext.azurefd.net"
+    record: "hmcts-nle-ext-h8cqggf7c7ffhbh4.z01.azurefd.net"
   - name: "pcnotify"
     ttl: 300
-    record: "hmcts-nle-ext.azurefd.net"
+    record: "hmcts-nle-ext-h8cqggf7c7ffhbh4.z01.azurefd.net"
   - name: "pcol"
     ttl: 300
-    record: "hmcts-nle-ext.azurefd.net"
+    record: "hmcts-nle-ext-h8cqggf7c7ffhbh4.z01.azurefd.net"
   - name: "sdt"
     ttl: 300
     record: "sdt-uks.apps-nle.hmcts.net"
@@ -51,7 +51,7 @@ cname:
     record: "sdtcomm-uks.apps-nle.hmcts.net"
   - name: "testclaim-pcol"
     ttl: 300
-    record: "hmcts-nle-ext.azurefd.net"
+    record: "hmcts-nle-ext-h8cqggf7c7ffhbh4.z01.azurefd.net"
   - name: "crimeportal"
     ttl: 300
     record: "hmcts-nle-int-cfgpbgagf9eedcar.z01.azurefd.net"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15899

### Change description ###

replaced CNAME of the hmcts-nle-ext frontdoor after migration.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

