### PR TITLE
VIH-10968 remove redundant cvp public dns records

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -159,10 +159,6 @@ A:
     ttl: 60
     record:
       - "20.58.20.26"
-  - name: "cvp-recording"
-    ttl: 60
-    record:
-      - "20.50.101.55"
   - name: "caps"
     ttl: 60
     record:

--- a/environments/sandbox/sandbox.yml
+++ b/environments/sandbox/sandbox.yml
@@ -27,21 +27,6 @@ A:
     record:
       - "51.140.180.140"
 
-  - name: "cvp-recording"
-    ttl: 60
-    record:
-      - "51.132.42.92"
-
-  - name: "cvp-recording-01"
-    ttl: 60
-    record:
-      - "51.132.41.247"
-
-  - name: "cvp-recording-02"
-    ttl: 60
-    record:
-      - "51.132.42.179"
-
   - name: "portal"
     ttl: 60
     record:

--- a/environments/staging/aat.yml
+++ b/environments/staging/aat.yml
@@ -9,21 +9,6 @@ srv: []
 txt: []
 
 A:
-  - name: "cvp-recording"
-    ttl: 60
-    record:
-      - "20.49.129.252"
-
-  - name: "cvp-recording-01"
-    ttl: 60
-    record:
-      - "20.49.130.27"
-
-  - name: "cvp-recording-02"
-    ttl: 60
-    record:
-      - "20.49.129.95"
-
   - name: "cft-mtls-api-mgmt-appgw"
     ttl: 300
     record:

--- a/shuttering/prod/platform-hmcts-net.yml
+++ b/shuttering/prod/platform-hmcts-net.yml
@@ -48,8 +48,6 @@ A:
     shutter: false
   - name: "vpn"
     shutter: false
-  - name: "cvp-recording"
-    shutter: false
   - name: "caps"
     shutter: false
   - name: "pcol"

--- a/shuttering/sandbox/sandbox.yml
+++ b/shuttering/sandbox/sandbox.yml
@@ -18,12 +18,6 @@ shutter_all_cname: false
 A:
   - name: "ctscmail"
     shutter: false
-  - name: "cvp-recording"
-    shutter: false
-  - name: "cvp-recording-01"
-    shutter: false
-  - name: "cvp-recording-02"
-    shutter: false
   - name: "portal"
     shutter: false
   - name: "cft-api-mgmt-appgw"


### PR DESCRIPTION
### Jira link

See [VIH-10968](https://tools.hmcts.net/jira/browse/VIH-10968)

### Change description

CVP Wowza frontends are now private, but there remains public DNS records pointing to non-existent public IP addresses. Dangling records should always be deleted for security.


### Testing done

Check all records to see if the public IP address no longer exists.

### Checklist

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] Does this PR introduce a breaking change
