### PR TITLE
Update staging-apps-hmcts-net.yml

### DIFF
--- a/environments/staging/staging-apps-hmcts-net.yml
+++ b/environments/staging/staging-apps-hmcts-net.yml
@@ -13,7 +13,15 @@ A:
     ttl: 300
     record:
       - "185.230.153.229"
-
+  - name: "libra"
+    ttl: 300
+    record:
+      - "185.230.153.230"
+  - name: "libra-preview"
+    ttl: 300
+    record:
+      - "185.230.153.230"
+      
 cname:
   - name: "glimr-preprod"
     ttl: 300


### PR DESCRIPTION
DLRM

Adding 2 new records to point to Cloud GW WAF VIP for 3rd party Libra access testing.

### Jira link
N/A - Manual

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Adding 2 additional A records to refer to the CG WAF - these URL's are for testing Internet access "whitelisted only to MoJ EUC ranges" to the CG WAF VIP for these 2 URL's
-->

### Testing done

<!-- Comment:
This is a new DNS entry which once done will be checked by public DNS lookup
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ X] commit messages are meaningful and follow good commit message guidelines
- [ X] README and other documentation has been updated / added (if needed)
- [X ] tests have been updated / new tests has been added (if needed)
- [X ] Does this PR introduce a breaking change
