### PR TITLE
New erupload URL in apps.hmcts.net

### DIFF
--- a/environments/prod/apps-hmcts-net.yml
+++ b/environments/prod/apps-hmcts-net.yml
@@ -95,3 +95,6 @@ cname:
     platform: "sds"
     ttl: 300
     record: "sdshmcts-prod-egd0dscwgwh0bpdq.z01.azurefd.net"
+  - name: "juror-er"
+    ttl: 300
+    record: "hmcts-heritage-prod-fug4hfanetgdf6cz.z01.azurefd.net"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-22305

Previously completed for STG:
- DNS: https://github.com/hmcts/azure-public-dns/pull/1908
- FD: https://github.com/hmcts/globalscape-azure-infrastructure/pull/294


This is all confirmed to be working correctly from new fqdn, so moving on to prod