### PR TITLE
DLRM - Libra via the Internet - Update apps-hmcts-net.yml

### DIFF
--- a/environments/prod/apps-hmcts-net.yml
+++ b/environments/prod/apps-hmcts-net.yml
@@ -55,6 +55,14 @@ A:
     ttl: 300
     record:
       - "185.230.153.228"
+  - name: "libra"
+    ttl: 300
+    record:
+      - "185.230.153.231"
+  - name: "libra-preview"
+    ttl: 300
+    record:
+      - "185.230.153.231"
 
 cname:
   - name: "caps"


### PR DESCRIPTION
Added 2 x A: records for DLRM Libra whitelisted application access from the Internet.

The A records point to the Cloud Gateway WAF service

### Jira link

This is a DLRM project 
Mark Coates is PM
Crime IT (Nick Bates) is involved

### Change description

This change adds 2 new A records to provide public DNS resolution for 2 new URL's to the CG WAF
libra.apps.hmcts.net
libra-preview.apps.hmcts.net

### Testing done

This has been done in staging.apps.hmcts.net successfully

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)
- [x ] Does this PR introduce a breaking change
