### PR TITLE
DTSPO-22820 Adding pubsub dns

### DIFF
--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -29,6 +29,11 @@ A:
     record:
       - "20.162.145.18"
 
+  - name: "em-icp-webpubsub"
+    ttl: 300
+    record:
+      - "20.162.145.90"
+
   - name: "darts-proxy"
     ttl: 300
     record:


### PR DESCRIPTION
### Jira link
[DTSPO-22820](https://tools.hmcts.net/jira/browse/DTSPO-22820)

### Change description

Adding dns for pubsub application gateway, ip to change when the pubsub app gateway gets created.

