### PR TITLE
DTSPO-22820 Updating public ip for pubsub

### DIFF
--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -32,7 +32,7 @@ A:
   - name: "em-icp-webpubsub"
     ttl: 300
     record:
-      - "20.162.145.90"
+      - "85.210.74.92"
 
   - name: "darts-proxy"
     ttl: 300


### PR DESCRIPTION
### Jira link

[DTSPO-22820](https://tools.hmcts.net/jira/browse/DTSPO-22820)

### Change description
Current ip on record is just a place holder until pubsub app gateway was created.  app gateway has now been created (cft-fe-00-demo-agw-pubsub), updating the pip on the record


