### PR TITLE
DTSPO-22820 adding dns entries for other envs for pubsub

### DIFF
--- a/environments/ithc/ithc.yml
+++ b/environments/ithc/ithc.yml
@@ -24,6 +24,11 @@ A:
     ttl: 3600
     record:
       - "20.254.18.242"
+      
+  - name: "em-icp-webpubsub"
+    ttl: 300
+    record:
+      - "85.210.74.92"
 
 txt:
   - name: "contact.justice"

--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -203,6 +203,10 @@ A:
     ttl: 300
     record:
       - "10.23.1.252"
+  - name: "em-icp-webpubsub"
+    ttl: 300
+    record:
+      - "85.210.74.92"
 
 txt:
   - name: "@"

--- a/environments/sandbox/sandbox.yml
+++ b/environments/sandbox/sandbox.yml
@@ -76,6 +76,11 @@ A:
     ttl: 300
     record:
       - "4.234.74.227"
+      
+  - name: "em-icp-webpubsub"
+    ttl: 300
+    record:
+      - "85.210.74.92"
 
 txt:
   - name: "contact.justice"

--- a/environments/staging/aat.yml
+++ b/environments/staging/aat.yml
@@ -14,6 +14,11 @@ A:
     record:
       - "20.26.101.168"
 
+  - name: "em-icp-webpubsub"
+    ttl: 300
+    record:
+      - "85.210.74.92"
+
 cname:
   - name: "_8c25cc47acd71d289bc2b0f6163f17bd"
     ttl: 900

--- a/environments/test/perftest.yml
+++ b/environments/test/perftest.yml
@@ -19,6 +19,11 @@ A:
     record:
       - "20.26.57.242"
 
+  - name: "em-icp-webpubsub"
+    ttl: 300
+    record:
+      - "85.210.74.92"
+
 cname:
   - name: "afdverify.benefit-appeal"
     ttl: 3600


### PR DESCRIPTION
### Jira link

[DTSPO-22820](https://tools.hmcts.net/jira/browse/DTSPO-22820)

### Change description

adding dns entries for other pubsub envs, the public ips are temp until the app gateways are created then these will be updated.

