### PR TITLE
DTSPO-23191 - shuttering staging atlassian for Flex migration""

### DIFF
--- a/shuttering/prod/hmcts-net.yml
+++ b/shuttering/prod/hmcts-net.yml
@@ -75,7 +75,7 @@ A:
   - name: tools.prp
     shutter: false
   - name: staging.tools
-    shutter: false
+    shutter: true
 
 cname:
   - name: "*.dev.cpp"


### PR DESCRIPTION
Reverts hmcts/azure-public-dns#1991

Shuttering staging Atlassian following Flex server migration issues.