### PR TITLE
Revert DTSPO-23191 - shuttering staging atlassian for Flex migration

### DIFF
--- a/shuttering/prod/hmcts-net.yml
+++ b/shuttering/prod/hmcts-net.yml
@@ -75,7 +75,7 @@ A:
   - name: tools.prp
     shutter: false
   - name: staging.tools
-    shutter: true
+    shutter: false
 
 cname:
   - name: "*.dev.cpp"


### PR DESCRIPTION
Reverts hmcts/azure-public-dns#1992

Taking shutter page down for Atlassian in staging