### PR TITLE
Revert "DTSPO-24218 - Atlassian shutter test (OOH)"

### DIFF
--- a/shuttering/prod/hmcts-net.yml
+++ b/shuttering/prod/hmcts-net.yml
@@ -71,7 +71,7 @@ A:
   - name: test-reform
     shutter: false
   - name: tools
-    shutter: true
+    shutter: false
   - name: tools.prp
     shutter: false
   - name: staging.tools


### PR DESCRIPTION
Reverts hmcts/azure-public-dns#1998

Test complete - success.