### PR TITLE
Add CNAMEs for test environment ssl renew validation

### DIFF
--- a/environments/prod/cjscp-org-uk.yml
+++ b/environments/prod/cjscp-org-uk.yml
@@ -541,3 +541,30 @@ cname:
   - name: _0mrxn7jkfvvt0dbk4yglzo6ojtr7pvu.www.rota.nft
     ttl: 10800
     record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.login.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.email-client.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.identity-gateway.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.manage-users.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.my-services.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.prosecuting-stub-idam.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.rota-stub-idam.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.token.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.
+  - name: _r7f1zo806ngbqj6rc7uija1lp2ndir7.cath-stub-idam.test.cjscp.org.uk
+    ttl: 10800
+    record: dcv.digicert.com.


### PR DESCRIPTION
### Jira link

See [DTSPO-25313](https://tools.hmcts.net/jira/browse/DTSPO-25313)

### Change description

Add domain ownership validation aliases for the purpose of renewing SSL certificate.

### Testing done

N/A

### Checklist

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [X] (NO) Does this PR introduce a breaking change
