### PR TITLE
DTSPO-25894: Add peach.dev dns

### DIFF
--- a/environments/prod/cjscp-org-uk.yml
+++ b/environments/prod/cjscp-org-uk.yml
@@ -222,6 +222,10 @@ A:
     ttl: 3600
     record:
       - 51.140.120.225
+  - name: peach.dev
+    ttl: 3600
+    record:
+      - 51.11.44.0
   - name: prosecuting
     ttl: 1800
     record:


### PR DESCRIPTION
[DTSPO-25894](https://tools.hmcts.net/jira/browse/DTSPO-25894)

Adds DNS record for peach pointing to DEV WAF `IP-DEV-DMZ-WAF-01`