### PR TITLE
labs-hurricanepilot-nodejs public dns config

### DIFF
--- a/environments/sandbox/sandbox.yml
+++ b/environments/sandbox/sandbox.yml
@@ -227,3 +227,11 @@ cname:
     record: "cnphmcts-classic-sbox.azurefd.net"
     shutter: false
     syncPrivateDNS: false
+    
+  - name: "labs-hurricanepilot-nodejs"
+    ttl: 300
+    record: "hmcts-sbox-gufqadefbjgbhkhv.z01.azurefd.net"
+    shutter: false
+  - name: "afdverify.labs-hurricanepilot-nodejs"
+    ttl: 300
+    record: "afdverify.hmcts-sbox-gufqadefbjgbhkhv.z01.azurefd.net"


### PR DESCRIPTION
### Change description

Adding public dns config for `labs-hurricanepilot-nodejs` as per instructions in the nodejs golden path