### PR TITLE
ADOP-2323: Shutter adoption citizen UI for redis cache release

### DIFF
--- a/shuttering/prod/apply-to-adopt-a-child-placed-in-your-care-service-gov-uk.yml
+++ b/shuttering/prod/apply-to-adopt-a-child-placed-in-your-care-service-gov-uk.yml
@@ -7,7 +7,7 @@ shutter_all: false
 # If you shutter all A records via the `shutter_all_a` setting and one of the records does not contain either of these values Terraform will fail.
 # - shutter_resource_id
 # - alias_target_resource_id
-shutter_all_a: false
+shutter_all_a: true
 
 shutter_all_cname: false
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ADOP-2323

### Change description

Shutter adoption Citizen UI for adoption release. Shuttering is expected to last from 02/10/25 7pm to 02/10/25 11pm. Change request: CHG-0058291

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
